### PR TITLE
Fixed override warning:

### DIFF
--- a/Source/Blu/Public/BluEye.h
+++ b/Source/Blu/Public/BluEye.h
@@ -168,7 +168,7 @@ class BLU_API UBluEye : public UObject
 
 	void TextureUpdate(const void* buffer);
 
-	void BeginDestroy() override;
+	void BeginDestroy() override; //
 
 	protected:
 		CefWindowInfo info;


### PR DESCRIPTION
warning C4996: OVERRIDE macro is deprecated.