### PR TITLE
Textures should always be unlocked

### DIFF
--- a/Source/Blu/Private/BluEye.cpp
+++ b/Source/Blu/Private/BluEye.cpp
@@ -124,8 +124,9 @@ void UBluEye::TextureUpdate(const void *buffer)
 			if (MipData)
 			{
 				FMemory::Memcpy(MipData, ImageData, DataSize);
-				GDynamicRHI->RHIUnlockTexture2D(TargetTexture, 0, false);
 			}
+
+			GDynamicRHI->RHIUnlockTexture2D(TargetTexture, 0, false);
 		});
 
 	}


### PR DESCRIPTION
It makes no sense to not unlock a texture, even if it has no data.