### PR TITLE
Replace deprecated GetModuleFilename in Build.cs

### DIFF
--- a/Source/Blu/Blu.Build.cs
+++ b/Source/Blu/Blu.Build.cs
@@ -6,14 +6,9 @@ using System;
 public class Blu : ModuleRules
 {
 
-	private string ModulePath
-	{
-		get { return Path.GetDirectoryName(RulesCompiler.GetModuleFilename(this.GetType().Name)); }
-	}
-
 	private string ThirdPartyPath
 	{
-		get { return Path.GetFullPath(Path.Combine(ModulePath, "../../ThirdParty/")); }
+		get { return Path.GetFullPath(Path.Combine(ModuleDirectory, "../../ThirdParty/")); }
 	}
 
 	private void stageFiles(String[] filesToStage)


### PR DESCRIPTION
This caused Visual Studio project file generation to fail in UE 4.12